### PR TITLE
Feature/reservation complete#18

### DIFF
--- a/src/main/java/com/eosugod/tradehub/reservation/controller/ReservationController.java
+++ b/src/main/java/com/eosugod/tradehub/reservation/controller/ReservationController.java
@@ -80,4 +80,12 @@ public class ReservationController {
         ResponseReservationDto responseDto = reservationService.cancelReservation(reservationId, userId);
         return ResponseEntity.ok(responseDto);
     }
+
+    // 거래 완료 요청 (판매자, 구매자)
+    @PatchMapping("/{reservationId}/complete/{userId}")
+    public ResponseEntity<ResponseReservationDto> completeReservation(@PathVariable Long reservationId,
+                                                                      @PathVariable Long userId) {
+        ResponseReservationDto responseDto = reservationService.completeReservation(reservationId, userId);
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/com/eosugod/tradehub/reservation/domain/ReservationDomain.java
+++ b/src/main/java/com/eosugod/tradehub/reservation/domain/ReservationDomain.java
@@ -23,6 +23,8 @@ public class ReservationDomain {
     private final Address locationCode;
     private final LocalDateTime confirmedAt;
     private final Reservation.ReservationState state;
+    private final boolean buyerCompleteRequest;
+    private final boolean sellerCompleteRequest;
     public ReservationDomain update(RequestUpdateReservationDto dto) {
         return ReservationDomain.builder()
                                 .id(this.id)
@@ -32,6 +34,8 @@ public class ReservationDomain {
                                 .locationCode(new Address(dto.getLocationCode()))
                                 .confirmedAt(dto.getConfirmedAt())
                                 .state(this.state)
+                                .buyerCompleteRequest(this.buyerCompleteRequest)
+                                .sellerCompleteRequest(this.sellerCompleteRequest)
                                 .build();
     }
 
@@ -44,6 +48,8 @@ public class ReservationDomain {
                 .locationCode(this.locationCode)
                 .confirmedAt(this.confirmedAt)
                 .state(newState)
+                .buyerCompleteRequest(this.buyerCompleteRequest)
+                .sellerCompleteRequest(this.sellerCompleteRequest)
                 .build();
     }
 
@@ -59,6 +65,22 @@ public class ReservationDomain {
                 .locationCode(this.locationCode)
                 .confirmedAt(this.confirmedAt)
                 .state(Reservation.ReservationState.CANCELLED)
+                .buyerCompleteRequest(this.buyerCompleteRequest)
+                .sellerCompleteRequest(this.sellerCompleteRequest)
+                .build();
+    }
+
+    public ReservationDomain completeRequest(boolean isBuyer, boolean isSeller) {
+        return ReservationDomain.builder()
+                .id(this.id)
+                .buyer(this.buyer)
+                .product(this.product)
+                .price(this.price)
+                .locationCode(this.locationCode)
+                .confirmedAt(this.confirmedAt)
+                .state(this.state)
+                .buyerCompleteRequest(isBuyer ? true : this.buyerCompleteRequest)
+                .sellerCompleteRequest(isSeller ? true : this.sellerCompleteRequest)
                 .build();
     }
 }

--- a/src/main/java/com/eosugod/tradehub/reservation/dto/response/ResponseReservationDto.java
+++ b/src/main/java/com/eosugod/tradehub/reservation/dto/response/ResponseReservationDto.java
@@ -20,4 +20,6 @@ public class ResponseReservationDto {
     private String locationCode;
     private String confirmedAt;
     private Reservation.ReservationState state;
+    private boolean buyerCompleteRequest;
+    private boolean sellerCompleteRequest;
 }

--- a/src/main/java/com/eosugod/tradehub/reservation/entity/Reservation.java
+++ b/src/main/java/com/eosugod/tradehub/reservation/entity/Reservation.java
@@ -40,6 +40,10 @@ public class Reservation {
 
     private ReservationState state;
 
+    private boolean buyerCompleteRequest = false;
+
+    private boolean sellerCompleteRequest = false;
+
     public enum ReservationState {
         PENDING, // 예약 대기
         CONFIRMED, // 예약 확정

--- a/src/main/java/com/eosugod/tradehub/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/com/eosugod/tradehub/reservation/mapper/ReservationMapper.java
@@ -24,6 +24,8 @@ public class ReservationMapper {
                 .locationCode(new Address(reservation.getLocationCode().getValue()))
                 .confirmedAt(reservation.getConfirmedAt())
                 .state(reservation.getState())
+                .buyerCompleteRequest(reservation.isBuyerCompleteRequest())
+                .sellerCompleteRequest(reservation.isSellerCompleteRequest())
                 .build();
     }
 
@@ -47,6 +49,8 @@ public class ReservationMapper {
                 .locationCode(new Address(reservationDomain.getLocationCode().getValue()))
                 .confirmedAt(reservationDomain.getConfirmedAt())
                 .state(reservationDomain.getState())
+                .buyerCompleteRequest(reservationDomain.isBuyerCompleteRequest())
+                .sellerCompleteRequest(reservationDomain.isSellerCompleteRequest())
                 .build();
     }
 
@@ -60,6 +64,8 @@ public class ReservationMapper {
                 .locationCode(reservationDomain.getLocationCode().getValue())
                 .confirmedAt(String.valueOf(reservationDomain.getConfirmedAt()))
                 .state(reservationDomain.getState())
+                .buyerCompleteRequest(reservationDomain.isBuyerCompleteRequest())
+                .sellerCompleteRequest(reservationDomain.isSellerCompleteRequest())
                 .build();
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈

거래 완료 구현

### ✨ 작업한 내용

거래 완료 구현

### 🌀 PR Point

### 🍰 참고사항

Reservation 필드에 buyer, seller가 거래 완료 요청을 보냈었는지 체크하는 boolean 필드 추가
buyer, seller가 모두 완료 요청을 보냈다면 거래 완료된 것임
거래 완료 시, product state - RESERVED -> SOLD_OUT 변경
reservation state - CONFIRMED -> COMPLETED 변경
seller cash가 reservation의 price만큼 대금을 지급함
